### PR TITLE
Ruleset registry testing isolation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ Changelog
 1.0.1 - Unreleased
 ------------------
 
+- Fix ruleset registry test isolation so that is no longer order dependent.
+  [jone]
+
 
 1.0 - 2011-05-13
 ----------------

--- a/plone/caching/testing.py
+++ b/plone/caching/testing.py
@@ -1,0 +1,43 @@
+from plone.testing import Layer
+from plone.testing.zca import UNIT_TESTING
+from z3c.caching.registry import getGlobalRulesetRegistry
+from z3c.caching.registry import RulesetRegistry
+from zope.component import provideAdapter
+import zope.component.testing
+
+
+class ImplicitRulesetRegistryUnitTestingLayer(Layer):
+    """Sets the z3c.caching registry into non-explicit mode.
+    Plone uses the explicit mode by default, requiring rules to be registred
+    as uilities explicitly.
+
+    The plone.caching unit tests do not register utilities and therefore
+    require the ruleset registry to be in non-explicit mode.
+
+    See the plone.app.caching.setuphandlers.enableExplicitMode ZCML
+    startup hook.
+    """
+
+    defaultBases = (UNIT_TESTING, )
+
+    def testSetUp(self):
+        provideAdapter(RulesetRegistry)
+        self.disable_explicit_mode()
+
+    def testTearDown(self):
+        self.reset_explicit_mode()
+        zope.component.testing.tearDown()
+
+    def disable_explicit_mode(self):
+        registry = getGlobalRulesetRegistry()
+        self._explicit_mode_cache = registry.explicit
+        registry.explicit = False
+
+    def reset_explicit_mode(self):
+        registry = getGlobalRulesetRegistry()
+        if registry is not None:
+            registry.explicit = self._explicit_mode_cache
+
+
+IMPLICIT_RULESET_REGISTRY_UNIT_TESTING = (
+    ImplicitRulesetRegistryUnitTestingLayer())

--- a/plone/caching/tests/test_hooks.py
+++ b/plone/caching/tests/test_hooks.py
@@ -1,13 +1,10 @@
 import unittest
 
-import zope.component.testing
-
 from zope.component import adapts, provideUtility, provideAdapter, getUtility
 from zope.interface import implements, Interface
 
 from zope.globalrequest import setRequest, clearRequest
 
-from z3c.caching.registry import RulesetRegistry
 import z3c.caching.registry
 
 from plone.registry.interfaces import IRegistry
@@ -26,6 +23,8 @@ from plone.caching.hooks import intercept
 from plone.caching.hooks import modifyStreamingResponse
 from plone.caching.hooks import Intercepted
 from plone.caching.hooks import InterceptorResponse
+
+from plone.caching.testing import IMPLICIT_RULESET_REGISTRY_UNIT_TESTING
 
 from ZODB.POSException import ConflictError
 
@@ -69,12 +68,10 @@ class DummyStreamingEvent(object):
 
 class TestMutateResponse(unittest.TestCase):
 
-    def setUp(self):
-        provideAdapter(RulesetRegistry)
-        provideAdapter(persistentFieldAdapter)
+    layer = IMPLICIT_RULESET_REGISTRY_UNIT_TESTING
 
-    def tearDown(self):
-        zope.component.testing.tearDown()
+    def setUp(self):
+        provideAdapter(persistentFieldAdapter)
 
     def test_no_published_object(self):
         provideAdapter(DefaultRulesetLookup)
@@ -389,13 +386,13 @@ class TestMutateResponse(unittest.TestCase):
 
 class TestMutateResponseStreaming(unittest.TestCase):
 
+    layer = IMPLICIT_RULESET_REGISTRY_UNIT_TESTING
+
     def setUp(self):
-        provideAdapter(RulesetRegistry)
         provideAdapter(persistentFieldAdapter)
 
     def tearDown(self):
         clearRequest()
-        zope.component.testing.tearDown()
 
     def test_no_published_object(self):
         provideAdapter(DefaultRulesetLookup)
@@ -738,12 +735,10 @@ class TestMutateResponseStreaming(unittest.TestCase):
 
 class TestIntercept(unittest.TestCase):
 
-    def setUp(self):
-        provideAdapter(RulesetRegistry)
-        provideAdapter(persistentFieldAdapter)
+    layer = IMPLICIT_RULESET_REGISTRY_UNIT_TESTING
 
-    def tearDown(self):
-        zope.component.testing.tearDown()
+    def setUp(self):
+        provideAdapter(persistentFieldAdapter)
 
     def test_no_published_object(self):
         provideAdapter(DefaultRulesetLookup)

--- a/plone/caching/tests/test_lookup.py
+++ b/plone/caching/tests/test_lookup.py
@@ -1,19 +1,17 @@
 import unittest
 
-import zope.component.testing
-
-from zope.component import provideAdapter
-
-from z3c.caching.registry import RulesetRegistry
 import z3c.caching.registry
 
 from plone.caching.lookup import DefaultRulesetLookup
+
+from plone.caching.testing import IMPLICIT_RULESET_REGISTRY_UNIT_TESTING
+
 
 class DummyView(object):
     pass
 
 class DummyResponse(dict):
-    
+
     def addHeader(self, name, value):
         self.setdefault(name, []).append(value)
 
@@ -23,22 +21,18 @@ class DummyRequest(dict):
         self.response = response
 
 class TestLookup(unittest.TestCase):
-    
-    def setUp(self):
-        provideAdapter(RulesetRegistry)
-    
-    def tearDown(self):
-        zope.component.testing.tearDown()
-    
+
+    layer = IMPLICIT_RULESET_REGISTRY_UNIT_TESTING
+
     def test_no_cache_rule(self):
         view = DummyView()
         request = DummyRequest(view, DummyResponse())
         self.assertEquals(None, DefaultRulesetLookup(view, request)())
-        
+
     def test_match(self):
         z3c.caching.registry.register(DummyView, 'testrule')
         view = DummyView()
-        request = DummyRequest(view, DummyResponse())        
+        request = DummyRequest(view, DummyResponse())
         self.assertEquals('testrule', DefaultRulesetLookup(view, request)())
 
 def test_suite():

--- a/plone/caching/tests/test_operations.py
+++ b/plone/caching/tests/test_operations.py
@@ -1,10 +1,7 @@
 import unittest
 
-import zope.component.testing
-
 from zope.interface import implements
 from zope.interface import Interface
-from z3c.caching.registry import RulesetRegistry
 
 from zope.component import provideUtility
 from zope.component import provideAdapter
@@ -17,16 +14,18 @@ from plone.registry import field
 from plone.caching.operations import Chain
 from plone.caching.interfaces import ICachingOperation
 
+from plone.caching.testing import IMPLICIT_RULESET_REGISTRY_UNIT_TESTING
+
 _marker = object()
 
 class DummyView(object):
     pass
 
 class DummyResponse(dict):
-    
+
     def addHeader(self, name, value):
         self.setdefault(name, []).append(value)
-    
+
     def setHeader(self, name, value):
         self[name] = value
 
@@ -37,156 +36,154 @@ class DummyRequest(dict):
 
 
 class TestChain(unittest.TestCase):
-    
+
+    layer = IMPLICIT_RULESET_REGISTRY_UNIT_TESTING
+
     def setUp(self):
         self.registry = Registry()
         provideUtility(self.registry, IRegistry)
-        provideAdapter(RulesetRegistry)
-    
-    def tearDown(self):
-        zope.component.testing.tearDown()
-    
+
     def test_no_option(self):
         view = DummyView()
         request = DummyRequest(view, DummyResponse())
-        
+
         chain = Chain(view, request)
         ret = chain.interceptResponse('testrule', request.response)
         chain.modifyResponse('testrule', request.response)
-        
+
         self.assertEquals(None, ret)
         self.assertEquals({'PUBLISHED': view}, dict(request))
         self.assertEquals({}, dict(request.response))
-    
+
     def test_operations_list_not_set(self):
-        
+
         self.registry.records["%s.operations" % Chain.prefix] = Record(field.List())
-        
+
         view = DummyView()
         request = DummyRequest(view, DummyResponse())
-        
+
         chain = Chain(view, request)
         ret = chain.interceptResponse('testrule', request.response)
         chain.modifyResponse('testrule', request.response)
-        
+
         self.assertEquals(None, ret)
         self.assertEquals({'PUBLISHED': view}, dict(request))
         self.assertEquals({}, dict(request.response))
-    
+
     def test_operations_empty(self):
-        
+
         self.registry.records["%s.operations" % Chain.prefix] = Record(field.List(), [])
-        
+
         view = DummyView()
         request = DummyRequest(view, DummyResponse())
-        
+
         chain = Chain(view, request)
         ret = chain.interceptResponse('testrule', request.response)
         chain.modifyResponse('testrule', request.response)
-        
+
         self.assertEquals(None, ret)
         self.assertEquals({'PUBLISHED': view}, dict(request))
         self.assertEquals({}, dict(request.response))
-    
+
     def test_chained_operations_not_found(self):
-        
+
         self.registry.records["%s.operations" % Chain.prefix] = Record(field.List(), ['op1'])
-        
+
         view = DummyView()
         request = DummyRequest(view, DummyResponse())
-        
+
         chain = Chain(view, request)
         chain.modifyResponse('testrule', request.response)
-        
+
         self.assertEquals({'PUBLISHED': view}, dict(request))
         self.assertEquals({}, dict(request.response))
-    
+
     def test_multiple_operations_one_found(self):
         self.registry.records["%s.operations" % Chain.prefix] = Record(field.List(), ['op1', 'op2'])
-        
+
         view = DummyView()
         request = DummyRequest(view, DummyResponse())
-        
+
         class DummyOperation(object):
             implements(ICachingOperation)
             adapts(Interface, Interface)
-            
+
             def __init__(self, published, request):
                 self.published = published
                 self.request = request
-            
+
             def interceptResponse(self, rulename, response):
                 return u"foo"
-            
+
             def modifyResponse(self, rulename, response):
                 response['X-Mutated'] = rulename
-        
+
         provideAdapter(DummyOperation, name="op2")
-        
+
         chain = Chain(view, request)
         ret = chain.interceptResponse('testrule', request.response)
-        
+
         self.assertEquals(u"foo", ret)
         self.assertEquals({'PUBLISHED': view}, dict(request))
         self.assertEquals({'X-Cache-Chain-Operations': 'op2'}, dict(request.response))
-        
+
         request = DummyRequest(view, DummyResponse())
         chain = Chain(view, request)
         chain.modifyResponse('testrule', request.response)
-        
+
         self.assertEquals({'PUBLISHED': view}, dict(request))
         self.assertEquals({'X-Mutated': 'testrule',
                            'X-Cache-Chain-Operations': 'op2'}, dict(request.response))
 
     def test_multiple_operations_multiple_found(self):
         self.registry.records["%s.operations" % Chain.prefix] = Record(field.List(), ['op1', 'op2'])
-        
+
         view = DummyView()
         request = DummyRequest(view, DummyResponse())
-        
+
         class DummyOperation1(object):
             implements(ICachingOperation)
             adapts(Interface, Interface)
-            
+
             def __init__(self, published, request):
                 self.published = published
                 self.request = request
-            
+
             def interceptResponse(self, rulename, response):
                 return u"foo"
-            
+
             def modifyResponse(self, rulename, response):
                 response['X-Mutated-1'] = rulename
-        
+
         provideAdapter(DummyOperation1, name="op1")
-        
+
         class DummyOperation2(object):
             implements(ICachingOperation)
             adapts(Interface, Interface)
-            
+
             def __init__(self, published, request):
                 self.published = published
                 self.request = request
-            
+
             def interceptResponse(self, rulename, response):
                 return u"bar"
-            
+
             def modifyResponse(self, rulename, response):
                 response['X-Mutated-2'] = rulename
-        
+
         provideAdapter(DummyOperation2, name="op2")
-        
+
         chain = Chain(view, request)
         ret = chain.interceptResponse('testrule', request.response)
-        
+
         self.assertEquals(u"foo", ret)
         self.assertEquals({'PUBLISHED': view}, dict(request))
         self.assertEquals({'X-Cache-Chain-Operations': 'op1'}, dict(request.response))
-        
+
         request = DummyRequest(view, DummyResponse())
         chain = Chain(view, request)
         chain.modifyResponse('testrule', request.response)
-        
+
         self.assertEquals({'PUBLISHED': view}, dict(request))
         self.assertEquals({'X-Mutated-1': 'testrule',
                            'X-Mutated-2': 'testrule',


### PR DESCRIPTION
Belongs to plone/Products.CMFPlone/issues/223

Most unit test in `plone.caching` rely on the fact they are run before all the Plone ZCML is loaded.
They rely on not having the `z3c.caching` ruleset registry in explicit mode.

**Problem**
The ruleset registry's explicit mode forces all rules to be registered as rule utility in the component registry, but the tests do not register any utilities. When the tests are run before integration tests this works well, but when the tests are run after integration tests the isolation is broken and results in errors such as:

``` python
Error in test test_operation_name_not_found (plone.caching.tests.test_hooks.TestMutateResponseStreaming)
Traceback (most recent call last):
  File "/Users/jone/projects/python/buildout.python/parts/opt/lib/python2.7/unittest/case.py", line 327, in run
    testMethod()
  File "/Users/jone/projects/python/cache/eggs/plone.caching-1.0-py2.7.egg/plone/caching/tests/test_hooks.py", line 512, in test_operation_name_not_found
    z3c.caching.registry.register(DummyView, 'testrule')
  File "/Users/jone/projects/python/cache/eggs/z3c.caching-2.0a1-py2.7.egg/z3c/caching/registry.py", line 144, in register
    return registry.register(obj, rule)
  File "/Users/jone/projects/python/cache/eggs/z3c.caching-2.0a1-py2.7.egg/z3c/caching/registry.py", line 64, in register
    raise LookupError("Explicit mode set and ruleset %s not found" % rule)
LookupError: Explicit mode set and ruleset testrule not found
```

The `plone.app.caching` [ZCML load hook](https://github.com/plone/plone.app.caching/blob/master/plone/app/caching/setuphandlers.py#L3) sets the ruleset registry into explicit mode, which is one of the sources of the isolation problem.

**Solution**
The proposed solution is to use a unit testing layer which makes sure that the ruleset registry is not in explicit mode.
This makes the tests order independent and thus fixes isolation problems.

**Background**
As discussed in plone/Products.CMFPlone/issues/223 adding packages with PloneTestCases (such as plone.app.versioningbehavior) to the same testing group results in a different testing order and the unit tests are no longer run before loading ZCML.

/cc @tisto 
