### PR TITLE
Remove five.globalrequest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
-
+- Remove five.globalrequest usage.
+  [gforcada]
 
 1.2.0 (2018-09-28)
 ------------------

--- a/plone/caching/configure.zcml
+++ b/plone/caching/configure.zcml
@@ -4,8 +4,6 @@
     xmlns:browser="http://namespaces.zope.org/browser"
     i18n_domain="plone">
 
-    <include package="five.globalrequest" />
-
     <include package="z3c.caching" file="meta.zcml" />
     <include package="z3c.caching" />
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(name='plone.caching',
           'zope.i18nmessageid',
           'zope.schema',
           'plone.transformchain',
-          'five.globalrequest',
           'Zope2 >= 2.12.4',
       ],
       entry_points="""


### PR DESCRIPTION
It has been deprecated on Zope 4